### PR TITLE
use pipe for easy reading

### DIFF
--- a/src/test/scala/B/EvaluatorTest.scala
+++ b/src/test/scala/B/EvaluatorTest.scala
@@ -1,6 +1,7 @@
 package B
 
 import org.scalatest.{Matchers, WordSpec}
+import scala.util.chaining._
 
 class EvaluatorTest extends WordSpec with Matchers {
 
@@ -13,18 +14,18 @@ class EvaluatorTest extends WordSpec with Matchers {
     }
     "apply to IfElse(True, t1, t2)" should {
       "be evaluating to Some(\"E-IFTRUE\", t1)" in {
-        Evaluator.evalOneStep(IfElse(True, True, True)) shouldEqual Some("E-IFTRUE", True)
-        Evaluator.evalOneStep(IfElse(True, True, False)) shouldEqual Some("E-IFTRUE", True)
-        Evaluator.evalOneStep(IfElse(True, False, True)) shouldEqual Some("E-IFTRUE", False)
-        Evaluator.evalOneStep(IfElse(True, False, False)) shouldEqual Some("E-IFTRUE", False)
+        IfElse(True, True, True) pipe Evaluator.evalOneStep shouldEqual Some("E-IFTRUE", True)
+        IfElse(True, True, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IFTRUE", True)
+        IfElse(True, False, True) pipe Evaluator.evalOneStep shouldEqual Some("E-IFTRUE", False)
+        IfElse(True, False, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IFTRUE", False)
       }
     }
     "apply to IfElse(False, t1, t2)" should {
       "be evaluating to Some(\"E-IFFALSE\", t2)" in {
-        Evaluator.evalOneStep(IfElse(False, True, True)) shouldEqual Some("E-IFFALSE", True)
-        Evaluator.evalOneStep(IfElse(False, True, False)) shouldEqual Some("E-IFFALSE", False)
-        Evaluator.evalOneStep(IfElse(False, False, True)) shouldEqual Some("E-IFFALSE", True)
-        Evaluator.evalOneStep(IfElse(False, False, False)) shouldEqual Some("E-IFFALSE", False)
+        IfElse(False, True, True) pipe Evaluator.evalOneStep shouldEqual Some("E-IFFALSE", True)
+        IfElse(False, True, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IFFALSE", False)
+        IfElse(False, False, True) pipe Evaluator.evalOneStep shouldEqual Some("E-IFFALSE", True)
+        IfElse(False, False, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IFFALSE", False)
       }
     }
     "apply to IfElse(t1, t2, t3)" when {
@@ -32,8 +33,8 @@ class EvaluatorTest extends WordSpec with Matchers {
         "IfElse(t1', t2, t3)" in {
           val case1 = IfElse(True, True, True)
           val case2 = IfElse(False, False, False)
-          Evaluator.evalOneStep(IfElse(case1, True, False)) shouldEqual Some("E-IF", IfElse(True, True, False))
-          Evaluator.evalOneStep(IfElse(case2, True, False)) shouldEqual Some("E-IF", IfElse(False, True, False))
+          IfElse(case1, True, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IF", IfElse(True, True, False))
+          IfElse(case2, True, False) pipe Evaluator.evalOneStep shouldEqual Some("E-IF", IfElse(False, True, False))
         }
       }
     }


### PR DESCRIPTION
scala 2.13ではscala.util.chaining._をインポートするとpipeが使えます
（|>という記号にはなっていない）

SyntaxとEvaluatorのようにデータ構造と実装を分けるタイプの書き方なら使うべき

https://www.scala-lang.org/api/2.13.x/scala/util/package$$chaining$.html